### PR TITLE
Fix the build for ppx_deriving.4.3

### DIFF
--- a/myocamlbuild.ml
+++ b/myocamlbuild.ml
@@ -5,21 +5,21 @@ let () = dispatch (
       Ocamlbuild_cppo.dispatcher hook ;
       match hook with
       | After_rules ->
-        let ppx_loc = (Findlib.query "ppx_deriving").Findlib.location in
-        let std_deriver deriver =
-          ppx_loc ^ "/" ^ deriver
-        in
-        flag ["ocaml";"link";"byte";"use_morphism"] &
-        A (ppx_loc ^ "/ppx_deriving_runtime.cma") ;
-        
-        flag ["ocaml";"link";"native";"use_morphism"] &
-        A (ppx_loc ^ "/ppx_deriving_runtime.cmxa") ;
-        
         flag ["ocaml"; "compile"; "use_morphism"] &
-        S[A"-I"; A ppx_loc ;
-          A"-ppx"; A("ocamlfind ppx_deriving/ppx_deriving "^
-                     "src/ppx_deriving_folder.cma "^
-                     "src/ppx_deriving_mapper.cma "^
-                     (std_deriver "ppx_deriving_show.cma")) ;
-         ]; 
+          Sh(String.chomp (run_and_read
+                               "ocamlfind printppx \
+                                ppx_deriving ppx_deriving.show \
+                                -ppxopt ppx_deriving,src/ppx_deriving_folder.cma \
+                                -ppxopt ppx_deriving,src/ppx_deriving_mapper.cma"));
+        let add_package tags package =
+          flag ("compile" :: "byte" :: tags)
+            (Findlib.compile_flags_byte [package]);
+          flag ("compile" :: "native" :: tags)
+            (Findlib.compile_flags_native [package]);
+          flag ("link" :: "byte" :: tags)
+            (Findlib.link_flags_byte [package]);
+          flag ("link" :: "native" :: tags)
+            (Findlib.link_flags_native [package]);
+        in
+        add_package ["ocaml"; "use_morphism"] (Findlib.query "ppx_deriving.runtime");
       | _ -> ())

--- a/opam
+++ b/opam
@@ -19,7 +19,7 @@ build-test: [
 depends: [
   "ppx_deriving" {>= "3.0" & < "5.0" }
   "ppx_tools" {>= "4.02.3"}
-  "ocamlfind"    {build}
+  "ocamlfind"    {build & >= "1.7.0"}
   "ocamlbuild" {build}
   "cppo"       {build}
   "cppo_ocamlbuild" {build}

--- a/opam
+++ b/opam
@@ -20,7 +20,9 @@ depends: [
   "ppx_deriving" {>= "3.0" & < "5.0" }
   "ppx_tools" {>= "4.02.3"}
   "ocamlfind"    {build}
+  "ocamlbuild" {build}
   "cppo"       {build}
+  "cppo_ocamlbuild" {build}
   "ounit"        {test}
   "ppx_import"   {test}
 ]


### PR DESCRIPTION
Fix the `ppx_deriving_morphism` build for the upcoming release of ppx_deriving.4.3, which changes the layout of installed object files and thus breaks the hardcoded paths in the build system of ppx_deriving_morphism. The new approach should also be compatible with older ppx_deriving releases.